### PR TITLE
Handle when $HOME for the container is not /root

### DIFF
--- a/tests/default-mock.sh
+++ b/tests/default-mock.sh
@@ -14,6 +14,12 @@ if match flatpak install flathub com.visualstudio.code ; then
     exit 0
 fi
 
+if match podman inspect toolbox-vscode-test \
+         --format='{{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}' ; then
+    echo "NAME=fedora-toolbox"
+    echo "HOME=/root"
+fi
+
 if match flatpak ps --columns=instance,application ; then
     exit 0
 fi

--- a/tests/framework/run-one-test.sh
+++ b/tests/framework/run-one-test.sh
@@ -33,11 +33,22 @@ ln -s /source/tests/framework/mock-flatpak-spawn.sh $bindir/flatpak-spawn
 
 ### Functions for tests
 
+fail() {
+    echo "$*" 1>&2
+    exit 1
+}
+
 assert_contents() {
     cat > /logs/expected
     if ! cmp -s /logs/expected "$1" ; then
         diff -u --label Expected --label "$1" /logs/expected "$1" 1>&2
         exit 1
+    fi
+}
+
+assert_grep() {
+    if ! grep -q "$1" "$2" ; then
+        fail "Failed to find '$1' in '$2'"
     fi
 }
 

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -11,6 +11,7 @@ test_basic() {
 
     assert_contents /logs/basic.cmd <<'EOF'
 flatpak list --app --columns=application
+podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
 flatpak ps --columns=instance,application
 flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
 EOF
@@ -76,6 +77,7 @@ test_installation() {
 flatpak list --app --columns=application
 flatpak remotes --columns=name
 flatpak install flathub com.visualstudio.code
+podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
 flatpak ps --columns=instance,application
 flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
 EOF
@@ -95,6 +97,7 @@ test_running() {
 
     assert_contents /logs/running.cmd <<'EOF'
 flatpak list --app --columns=application
+podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
 flatpak ps --columns=instance,application
 flatpak enter 123456 sh -c 
         cd $0

--- a/tests/test-server-dir.sh
+++ b/tests/test-server-dir.sh
@@ -1,0 +1,101 @@
+# Different versions of toolbox+podman result in different  values of the HOME
+# environment variable in the container config. Since that determines the
+# location where Visual Studio Code puts the '.vscode-server' directory,
+# we have to handle them all.
+
+# shellcheck shell=bash
+
+do_mock_server_dir() {
+    if match podman inspect toolbox-vscode-test \
+             --format='{{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}' ; then
+        echo "NAME=fedora-toolbox"
+        echo "HOME=$1"
+        exit 1
+fi
+}
+
+### HOME=/
+
+mock_server_dir_topdir() {
+    do_mock_server_dir /
+}
+
+test_server_dir_topdir() {
+    code .
+    assert_grep '"remote.containers.copyGitConfig": false' \
+                /.vscode-server/data/Machine/settings.json
+}
+
+### HOME=/root
+
+mock_server_dir_root() {
+    do_mock_server_dir /root
+}
+
+test_server_dir_root() {
+    code .
+    assert_grep '"remote.containers.copyGitConfig": false' \
+                /root/.vscode-server/data/Machine/settings.json
+}
+
+### HOME=/home/testuser
+
+check_home_symlink() {
+    if [ ! -L /home/testuser/.vscode-server ] || \
+           [ "$(readlink /home/testuser/.vscode-server)" != "/.vscode-server" ] ; then
+        fail "Link to /.vscode/server wasn't created succesfully"
+    fi
+}
+
+mock_server_dir_home() {
+    do_mock_server_dir /home/testuser
+}
+
+test_server_dir_home() {
+    code .
+    check_home_symlink
+    assert_grep '"remote.containers.copyGitConfig": false' \
+                /home/testuser/.vscode-server/data/Machine/settings.json
+}
+
+### HOME=/home/testuser, symlink at ~/.vscode-server points somewhere else
+
+mock_server_dir_home_old_symlink() {
+    do_mock_server_dir /home/testuser
+}
+
+test_server_dir_home_old_symlink() {
+    ln -s /bah/bah /home/testuser/.vscode-server
+    code .
+    check_home_symlink
+    assert_grep '"remote.containers.copyGitConfig": false' \
+                /home/testuser/.vscode-server/data/Machine/settings.json
+}
+
+### HOME=/home/testuser, ~/.vscode-server exists and isn't a symlink
+
+mock_server_dir_home_old_dir() {
+    do_mock_server_dir /home/testuser
+}
+
+test_server_dir_home_old_dir() {
+    mkdir /home/testuser/.vscode-server
+    code . 2>&1 | tee /logs/server_dir_home_old_dir.stdout
+    [[ ${PIPESTATUS[0]} = 1 ]] || fail "Should have exited unsuccessfully"
+    assert_grep "$HOME/.vscode-server is not a symlink - this is probably a left-over." \
+                /logs/server_dir_home_old_dir.stdout
+}
+
+### HOME=<somehwere else
+
+mock_server_dir_unknown() {
+    do_mock_server_dir /home/otheruser
+}
+
+test_server_dir_unknown() {
+    code . 2>&1 | tee /logs/server_dir_unknown.stdout
+    [[ ${PIPESTATUS[0]} = 1 ]] || fail "Should have exited unsuccessfully"
+    assert_grep "\$HOME in container config is: '/home/otheruser' - don't know how to handle this." \
+                /logs/server_dir_unknown.stdout
+}
+


### PR DESCRIPTION
Visual Studio Code uses HOME from the container config to determine
where it puts .vscode-server. Toolboxes created with older versions of
toolbox+podman have HOME=/root, but with newer versions, we might end up with
HOME=/var/home/<user> or HOME=/.

Handle all these cases. In particular for the user-home-directory case,
put a symlink from /var/home/<user>/.vscode-server => /.vscode-server
to make sure that the configuration is properly per-container.