### PR TITLE
Use podman-host.sh to pass all envvars to the container

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -329,7 +329,7 @@ fi
 global_storage="$HOME/.var/app/com.visualstudio.code/config/Code/User/globalStorage"
 name_config="$global_storage/ms-vscode-remote.remote-containers/nameConfigs/$container_name.json"
 if $toolbox_reset_configuration || [ ! -f "$name_config" ] ; then
-    # The reason for including $PATH in removeEnv is so that any path modifications
+    # The reason for including $PATH in remoteEnv is so that any path modifications
     # set up in ~/.bashrc / ~/.bash_profile are present in the environment where
     # vscode runs commands, not just in the interactive terminal. As a special case
     # we remove any Python virtualenv path, in case this script is being invoked
@@ -346,18 +346,7 @@ if $toolbox_reset_configuration || [ ! -f "$name_config" ] ; then
   // "name": "Toolbox $container_name",
   "remoteUser": "\${localEnv:USER}",
   "remoteEnv": {
-    "COLORTERM": "\${localEnv:COLORTERM}",
-    "DBUS_SESSION_BUS_ADDRESS": "\${localEnv:DBUS_SESSION_BUS_ADDRESS}",
-    "DESKTOP_SESSION": "\${localEnv:DESKTOP_SESSION}",
-    "LANG": "\${localEnv:LANG}",
-    "PATH": "$PATH",
-    "TERM": "\${localEnv:TERM}",
-    "XDG_CURRENT_DESKTOP": "\${localEnv:XDG_CURRENT_DESKTOP}",
-    "XDG_DATA_DIRS": "\${localEnv:XDG_DATA_DIRS}",
-    "XDG_MENU_PREFIX": "\${localEnv:XDG_MENU_PREFIX}",
-    "XDG_RUNTIME_DIR": "\${localEnv:XDG_RUNTIME_DIR}",
-    "XDG_SESSION_DESKTOP": "\${localEnv:XDG_SESSION_DESKTOP}",
-    "XDG_SESSION_TYPE": "\${localEnv:XDG_SESSION_TYPE}"
+    "PATH": "$PATH"
   }
 }
 EOF

--- a/podman-host.sh
+++ b/podman-host.sh
@@ -3,13 +3,30 @@
 if [ "$1" == "exec" ] ; then
     # Remove 'exec' from $@
     shift
+    # We want to match toolbox in what variables from the host pass into the container
+    # https://github.com/containers/toolbox/blob/master/src/pkg/utils/utils.go#L67-L90
+    # We omit: COLORTERM, TERM, VTE_VERSION
     # shellcheck disable=SC1004,SC2016
     script='
-        exec podman exec \
-            -e DISPLAY="$DISPLAY" \
-            -e SHELL="$SHELL" \
-            -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
-        "$@"
+        envargs=()
+        for var in \
+            DBUS_{SESSION,SYSTEM}_BUS_ADDRESS \
+            DESKTOP_SESSION \
+            DISPLAY \
+            LANG \
+            SHELL \
+            SSH_AUTH_SOCK \
+            USER \
+            WAYLAND_DISPLAY \
+            XAUTHORITY \
+            XDG_{CURRENT_DESKTOP,DATA_DIRS,MENU_PREFIX,RUNTIME_DIR,SEAT,VTNR} \
+            XDG_SESSION_{DESKTOP,ID,TYPE} \
+        ; do
+            if [ "${!var+set}" = "set" ] ; then
+                envargs+=(-e "$var=${!var}")
+            fi
+        done
+        exec podman exec "${envargs[@]}" "$@"
     '
     exec flatpak-spawn --host sh -c "$script" - "$@"
 else

--- a/tests/default-mock.sh
+++ b/tests/default-mock.sh
@@ -18,6 +18,7 @@ if match podman inspect toolbox-vscode-test \
          --format='{{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}' ; then
     echo "NAME=fedora-toolbox"
     echo "HOME=/root"
+    exit 0
 fi
 
 if match flatpak ps --columns=instance,application ; then

--- a/tests/framework/mock-flatpak-spawn.sh
+++ b/tests/framework/mock-flatpak-spawn.sh
@@ -38,4 +38,4 @@ fi
 . /source/tests/default-mock.sh
 
 echo "$0: unmatched: $*" 1>&2
-exit
+exit 1

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -45,18 +45,7 @@ EOF
   // "name": "Toolbox toolbox-vscode-test",
   "remoteUser": "${localEnv:USER}",
   "remoteEnv": {
-    "COLORTERM": "${localEnv:COLORTERM}",
-    "DBUS_SESSION_BUS_ADDRESS": "${localEnv:DBUS_SESSION_BUS_ADDRESS}",
-    "DESKTOP_SESSION": "${localEnv:DESKTOP_SESSION}",
-    "LANG": "${localEnv:LANG}",
-    "PATH": "/home/testuser/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-    "TERM": "${localEnv:TERM}",
-    "XDG_CURRENT_DESKTOP": "${localEnv:XDG_CURRENT_DESKTOP}",
-    "XDG_DATA_DIRS": "${localEnv:XDG_DATA_DIRS}",
-    "XDG_MENU_PREFIX": "${localEnv:XDG_MENU_PREFIX}",
-    "XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
-    "XDG_SESSION_DESKTOP": "${localEnv:XDG_SESSION_DESKTOP}",
-    "XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}"
+    "PATH": "/home/testuser/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   }
 }
 EOF

--- a/tests/test-podman-host.sh
+++ b/tests/test-podman-host.sh
@@ -51,6 +51,6 @@ EOF
         fail "podman-host exited unsuccessfully"
 
     assert_grep \
-        "podman exec -e DISPLAY= -e SHELL=/bin/bash -e SSH_AUTH_SOCK= test-toolbox-vscode env" \
+        "podman exec -e SHELL=/bin/bash test-toolbox-vscode env" \
         /logs/podman_host_exec.cmd
 }

--- a/tests/test-podman-host.sh
+++ b/tests/test-podman-host.sh
@@ -1,0 +1,56 @@
+# shellcheck shell=bash
+
+### Test podman-host <anything but exec>
+
+mock_podman_host() {
+    if match podman --version ; then
+        echo "podman version 3.0.1"
+        exit 0
+    fi
+}
+
+test_podman_host() {
+    # Sets up the podman-host symlink
+    code --help
+
+    version=$(podman-host --version) || fail "podman-host exited unsuccessfully"
+
+    [[ $version = "podman version 3.0.1" ]] || fail "Didn't get mocked version"
+}
+
+### Test podman-host exec
+
+mock_podman_host_exec() {
+    if match sh @ ; then
+        # flatpak-spawn --host sh -c "$script" - "$@"
+        #
+        # Where $script builds and executes a 'podman exec' command
+        # line.
+        #
+        # To make sure that the script is generating the
+        # right podman command line, we execute the script, with
+        # a podman command that just logs its args
+
+        # shellcheck disable=SC2154
+        "${args[@]}"
+        exit 0
+    fi
+}
+
+test_podman_host_exec() {
+    # Sets up the podman-host symlink
+    code --help
+
+    cat > /home/testuser/.local/bin/podman <<'EOF'
+#!/bin/bash
+echo podman "$*" >> "/logs/$TEST_NAME.cmd"
+EOF
+    chmod a+x /home/testuser/.local/bin/podman
+
+    podman-host exec test-toolbox-vscode env || \
+        fail "podman-host exited unsuccessfully"
+
+    assert_grep \
+        "podman exec -e DISPLAY= -e SHELL=/bin/bash -e SSH_AUTH_SOCK= test-toolbox-vscode env" \
+        /logs/podman_host_exec.cmd
+}


### PR DESCRIPTION
While DISPLAY, SHELL, SSH_AUTH_SOCK were examples where the toolbox environment
were noticeably different from the Flaptak sandbox environment, other variables
such as DBUS_SESSION_BUS_ADDRESS were only coincidentally the same - so use the
podman-host wrapper to pass all the variables that toolbox "leaks" into the
container, instead of just these three. The list of variables is updated from
the toolbox sources and irrelevant terminal variables (TERM, COLORTERM, VTE_VERSION)
are omitted.

The only variable we leave in remoteEnv is $PATH, which we set so that extra
paths added added by the login shell, like ~/bin, are in the environment for tools
executed directly by Visual Studio Code.