### PR TITLE
workflows/ci.yml: Run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,14 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             ./shellcheck.sh
+
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./run-tests.sh


### PR DESCRIPTION
Add run-tests.sh to the CI github action. We use the podman version
from the Ubuntu runtime; this pulls in crun as a dependency, but not
crun, so we need to edit the config (and crun is better match for
the normal podman environment anyways.)