### PR TITLE
Update existing-process workaround

### DIFF
--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -12,7 +12,7 @@ test_basic() {
     assert_contents /logs/basic.cmd <<'EOF'
 flatpak list --app --columns=application
 podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
-flatpak ps --columns=instance,application
+flatpak ps --columns=instance,application,pid
 flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
 EOF
 
@@ -67,19 +67,31 @@ flatpak list --app --columns=application
 flatpak remotes --columns=name
 flatpak install flathub com.visualstudio.code
 podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
-flatpak ps --columns=instance,application
+flatpak ps --columns=instance,application,pid
 flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
 EOF
 }
 
 mock_running() {
-    if match flatpak ps --columns=instance,application ; then
-        echo "123456 com.visualstudio.code"
+    if match flatpak ps --columns=instance,application,pid ; then
+        # Stray leftover
+        echo "424242 com.visualstudio.code 999"
+        # Child
+        echo "654321 com.visualstudio.code 234"
+        # Host - the way we want
+        echo "123456 com.visualstudio.code 123"
         exit 0
     fi
 }
 
 test_running() {
+    export TOOLBOX_VSCODE_FAKE_PROC=$HOME/proc
+
+    mkdir -p ~/proc/234
+    mkdir -p ~/proc/123
+    echo -ne 'bwrap\0--args\000042\0/app/bin/zypak-helper\0child\0' > ~/proc/234/cmdline
+    echo -ne 'bwrap\0--args\000040\0/app/bin/zypak-helper\0host\0' > ~/proc/123/cmdline
+
     mkdir ~/project
     cd ~/project || exit 1
     code --toolbox-verbose .
@@ -87,12 +99,21 @@ test_running() {
     assert_contents /logs/running.cmd <<'EOF'
 flatpak list --app --columns=application
 podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ . }}{{"\n"}}{{ end }}
-flatpak ps --columns=instance,application
+flatpak ps --columns=instance,application,pid
 flatpak enter 123456 sh -c 
         cd $0
-        DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus \
-        DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket \
+        HOME=$1
+        shift
+        DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus
+        DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+        XDG_DATA_HOME="$HOME/.var/app/com.visualstudio.code/data"
+        XDG_CONFIG_HOME="$HOME/.var/app/com.visualstudio.code/config"
+        XDG_CACHE_HOME="$HOME/.var/app/com.visualstudio.code/cache"
+        export HOME DBUS_SESSION_BUS_ADDRESS DBUS_SYSTEM_BUS_ADDRESS \
+            XDG_CACHE_HOME XDG_CONFIG_HOME XDG_DATA_HOME
+        ELECTRON_RUN_AS_NODE=1 \
+        PATH="${PATH}:$XDG_CONFIG_HOME/node_modules/bin" \
             exec "$@"
-     /home/testuser/project code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
+     /home/testuser/project /home/testuser /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js --extensions-dir=/home/testuser/.var/app/com.visualstudio.code/data/vscode/extensions --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
 EOF
 }


### PR DESCRIPTION
Wth the port of the vscode of the Visual Studio Code Flatpak to
https://github.com/refi64/zypak and other changes, the code we had
to find an existing process and create a window in that wasn't working.

- Distinguish the host and client Zypak processes, which show up as
  separate instances of the Flatpak application. The client process
  isn't suitable for reuse.
- Set an explicit environment for 'flatpak enter', since something is
  making Flatpak's code to read /proc/<pid>/environ not work for the
  host Zypak process.
- When we are just expecting vscode to talk to the existing process,
  bypass the Zypak wrapper and call the vscode executable directly for
  speed.