### PR TITLE
code.sh: Make more robust against installation problems

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -70,10 +70,16 @@ read_cmdline() {
     return 0
 }
 
-# We'll later read the symlink to find podman-host.sh
-
 if [ ! -L "$0" ] ; then
     echo "$(basename "$0"): Only symlinked installation currently supported" 1>&2
+    exit 1
+fi
+
+code_sh="$(readlink "$0")"
+podman_host_sh="$(dirname "$code_sh")/podman-host.sh"
+
+if [ ! -f "$podman_host_sh" ] ; then
+    echo "$(basename "$0"): $0 should be a symlink to code.sh in the toolbox-vscode checkout" 1>&2
     exit 1
 fi
 
@@ -241,9 +247,6 @@ else
 fi
 
 ### Make sure that we have a podman wrapper configured
-
-code_sh="$(readlink "$0")"
-podman_host_sh="$(dirname "$code_sh")/podman-host.sh"
 
 podman_wrapper="$HOME/.local/bin/podman-host"
 if [ "$(readlink "$podman_wrapper")" != "$podman_host_sh" ] ; then

--- a/tests/test-installation.sh
+++ b/tests/test-installation.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=bash
+
+mock_no_symlink() {
+    :
+}
+
+test_no_symlink() {
+    mkdir ~/project
+    cd ~/project || exit 1
+    if /source/code.sh --toolbox-verbose . > out 2>&1 ; then
+        echo "Running script directly should fail"
+        return 1
+    fi || :
+    assert_contents out <<'EOF'
+code.sh: Only symlinked installation currently supported
+EOF
+}
+
+mock_two_symlinks() {
+    :
+}
+
+test_two_symlinks() {
+    mkdir ~/project
+    cd ~/project || exit 1
+    ln -s /home/testuser/.local/bin/code .
+    if ./code --toolbox-verbose . > out 2>&1 ; then
+        echo "Running script through double symlink should fail"
+        return 1
+    fi || :
+    assert_contents out <<'EOF'
+code: ./code should be a symlink to code.sh in the toolbox-vscode checkout
+EOF
+}


### PR DESCRIPTION
If code.sh was a symlink but not a direct symlink to the installation
directory, that caused hard to resolve problems. Check the value we
get from readlink to make sure that podman-host.sh is where we expect.

Fixes #6