### PR TITLE
Update code.sh to use new VSCode integrated terminal profiles

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -383,16 +383,21 @@ if $toolbox_reset_configuration || [ ! -f $settings ] ; then
 {
   "remote.containers.copyGitConfig": false,
   "remote.containers.gitCredentialHelperConfigLocation": "none",
-  "terminal.integrated.shell.linux": "/usr/sbin/capsh",
-  "terminal.integrated.shellArgs.linux": [
-    "--caps=",
-    "--",
-    "-c",
-    "exec \"\$@\"",
-    "/bin/sh",
-    "$SHELL",
-    "-l"
-  ]
+  "terminal.integrated.defaultProfile.linux": "toolbox",
+  "terminal.integrated.profiles.linux": {
+    "toolbox": {
+      "path": "/usr/sbin/capsh",
+      "args": [
+        "--caps=",
+        "--",
+        "-c",
+        "exec \"\$@\"",
+        "/bin/sh",
+        "$SHELL",
+        "-l"
+      ]
+    }
+  }
 }
 EOF
 fi

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -26,16 +26,21 @@ EOF
 {
   "remote.containers.copyGitConfig": false,
   "remote.containers.gitCredentialHelperConfigLocation": "none",
-  "terminal.integrated.shell.linux": "/usr/sbin/capsh",
-  "terminal.integrated.shellArgs.linux": [
-    "--caps=",
-    "--",
-    "-c",
-    "exec \"$@\"",
-    "/bin/sh",
-    "/bin/bash",
-    "-l"
-  ]
+  "terminal.integrated.defaultProfile.linux": "toolbox",
+  "terminal.integrated.profiles.linux": {
+    "toolbox": {
+      "path": "/usr/sbin/capsh",
+      "args": [
+        "--caps=",
+        "--",
+        "-c",
+        "exec \"$@\"",
+        "/bin/sh",
+        "/bin/bash",
+        "-l"
+      ]
+    }
+  }
 }
 EOF
 


### PR DESCRIPTION
This PR replaces deprecated VSCode setting `terminal.integrated.shell.linux` in favour of new `terminal.integrated.profiles.linux` one.