### PR TITLE
Convert raw command line arguments to --file-uri and --folder-uri

### DIFF
--- a/tests/test-arg-parsing.sh
+++ b/tests/test-arg-parsing.sh
@@ -5,6 +5,7 @@ mock_arg_parsing() {
 }
 
 ENCODED_REMOTE=746f6f6c626f782d7673636f64652d74657374
+URI_PREFIX=vscode-remote://attached-container+$ENCODED_REMOTE
 
 assert_args() {
     tail -n 1 /logs/arg_parsing.cmd > /logs/arg_parsing.cmd.last
@@ -14,17 +15,27 @@ EOF
 }
 
 test_arg_parsing() {
+    mkdir MyProject
+
     code
     assert_args --new-window
 
     code .
-    assert_args /home/testuser
+    assert_args --folder-uri "$URI_PREFIX/home/testuser"
 
     code MyProject
-    assert_args /home/testuser/MyProject
+    assert_args --folder-uri "$URI_PREFIX/home/testuser/MyProject"
 
-    code /MyProject
-    assert_args /MyProject
+    code /home/testuser/MyProject
+    assert_args --folder-uri "$URI_PREFIX/home/testuser/MyProject"
+
+    # Anything that isn't an existing folder should be treated as a file
+    code /home/testuser/somefile.py
+    assert_args --file-uri "$URI_PREFIX/home/testuser/somefile.py"
+
+    # Test escaping
+    code /home/testuser/"%#?.py"
+    assert_args --file-uri "$URI_PREFIX/home/testuser/%25%23%3F.py"
 
     code --file-uri=file:///home/testuser
     assert_args --file-uri=file:///home/testuser

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -9,11 +9,12 @@ test_basic() {
     cd ~/project || exit 1
     code --toolbox-verbose .
 
-    assert_contents /logs/basic.cmd <<'EOF'
+    AUTHORITY=attached-container+746f6f6c626f782d7673636f64652d74657374
+    assert_contents /logs/basic.cmd <<EOF
 flatpak list --app --columns=application
 podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ println . }}{{ end }}
 flatpak ps --columns=instance,application,pid
-flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
+flatpak run com.visualstudio.code --remote $AUTHORITY --folder-uri vscode-remote://$AUTHORITY/home/testuser/project
 EOF
 
     assert_contents /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
@@ -67,13 +68,14 @@ test_installation() {
     cd ~/project || exit 1
     yes | code --toolbox-verbose .
 
-    assert_contents /logs/installation.cmd <<'EOF'
+    AUTHORITY=attached-container+746f6f6c626f782d7673636f64652d74657374
+    assert_contents /logs/installation.cmd <<EOF
 flatpak list --app --columns=application
 flatpak remotes --columns=name
 flatpak install flathub com.visualstudio.code
 podman inspect toolbox-vscode-test --format={{ range .Config.Env }}{{ println . }}{{ end }}
 flatpak ps --columns=instance,application,pid
-flatpak run com.visualstudio.code --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
+flatpak run com.visualstudio.code --remote $AUTHORITY --folder-uri vscode-remote://$AUTHORITY/home/testuser/project
 EOF
 }
 
@@ -119,6 +121,6 @@ flatpak enter 123456 sh -c
         ELECTRON_RUN_AS_NODE=1 \
         PATH="${PATH}:$XDG_CONFIG_HOME/node_modules/bin" \
             exec "$@"
-     /home/testuser/project /home/testuser /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js --ms-enable-electron-run-as-node --extensions-dir=/home/testuser/.var/app/com.visualstudio.code/data/vscode/extensions --remote attached-container+746f6f6c626f782d7673636f64652d74657374 /home/testuser/project
+     /home/testuser/project /home/testuser /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js --ms-enable-electron-run-as-node --extensions-dir=/home/testuser/.var/app/com.visualstudio.code/data/vscode/extensions --remote attached-container+746f6f6c626f782d7673636f64652d74657374 --folder-uri vscode-remote://attached-container+746f6f6c626f782d7673636f64652d74657374/home/testuser/project
 EOF
 }


### PR DESCRIPTION
Calling Visual Studio Code with

   '--remote attached-container+<xxx>' <PATH1> <PATH2>

Resolves <PATH1> and <PATH2> to folder-or-file based on heuristics
before passing them to the remote container. So it's better to check
locally whether paths are folders or files and use the --file-uri and
--folder-uri arguments.

Fixes: #14