### PR TITLE
Update Dev Container extension settings prefix to dev.containers.

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -268,17 +268,17 @@ if [ ! -f "$settings_json" ] ; then
     mkdir -p "$(dirname "$settings_json")"
     cat > "$settings_json" <<EOF
 {
-  "remote.containers.dockerPath": "$podman_wrapper"
+  "dev.containers.dockerPath": "$podman_wrapper"
 }
 EOF
-elif ! grep -q '"remote\.containers\.dockerPath": *"'"$wrapper_quoted"'"' "$settings_json" ; then
-    if ! grep -q '"remote\.containers\.dockerPath"' "$settings_json" ; then
-        info "Editing $settings_json to add remote.containers.dockerPath"
-        sed -i '1s@{@{\n    "remote.containers.dockerPath": "'"$podman_wrapper"'",@' \
+elif ! grep -q '"dev\.containers\.dockerPath": *"'"$wrapper_quoted"'"' "$settings_json" ; then
+    if ! grep -q '"dev\.containers\.dockerPath"' "$settings_json" ; then
+        info "Editing $settings_json to add dev.containers.dockerPath"
+        sed -i '1s@{@{\n    "dev.containers.dockerPath": "'"$podman_wrapper"'",@' \
             "$settings_json"
     else
-        info "Editing $settings_json to update remote.containers.dockerPath"
-        sed -i -r 's@("remote.containers.dockerPath": *")[^"]*@\1'"$podman_wrapper"'@' \
+        info "Editing $settings_json to update dev.containers.dockerPath"
+        sed -i -r 's@("dev.containers.dockerPath": *")[^"]*@\1'"$podman_wrapper"'@' \
             "$settings_json"
     fi
 fi
@@ -381,8 +381,8 @@ if $toolbox_reset_configuration || [ ! -f $settings ] ; then
     mkdir -p "$(dirname $settings)"
     cat > $settings <<EOF
 {
-  "remote.containers.copyGitConfig": false,
-  "remote.containers.gitCredentialHelperConfigLocation": "none",
+  "dev.containers.copyGitConfig": false,
+  "dev.containers.gitCredentialHelperConfigLocation": "none",
   "terminal.integrated.defaultProfile.linux": "toolbox",
   "terminal.integrated.profiles.linux": {
     "toolbox": {

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -18,14 +18,14 @@ EOF
 
     assert_contents /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
 {
-  "remote.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
+  "dev.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
 }
 EOF
 
     assert_contents /root/.vscode-server/data/Machine/settings.json <<'EOF'
 {
-  "remote.containers.copyGitConfig": false,
-  "remote.containers.gitCredentialHelperConfigLocation": "none",
+  "dev.containers.copyGitConfig": false,
+  "dev.containers.gitCredentialHelperConfigLocation": "none",
   "terminal.integrated.defaultProfile.linux": "toolbox",
   "terminal.integrated.profiles.linux": {
     "toolbox": {

--- a/tests/test-server-dir.sh
+++ b/tests/test-server-dir.sh
@@ -22,7 +22,7 @@ mock_server_dir_topdir() {
 
 test_server_dir_topdir() {
     code .
-    assert_grep '"remote.containers.copyGitConfig": false' \
+    assert_grep '"dev.containers.copyGitConfig": false' \
                 /.vscode-server/data/Machine/settings.json
 }
 
@@ -34,7 +34,7 @@ mock_server_dir_root() {
 
 test_server_dir_root() {
     code .
-    assert_grep '"remote.containers.copyGitConfig": false' \
+    assert_grep '"dev.containers.copyGitConfig": false' \
                 /root/.vscode-server/data/Machine/settings.json
 }
 
@@ -54,7 +54,7 @@ mock_server_dir_home() {
 test_server_dir_home() {
     code .
     check_home_symlink
-    assert_grep '"remote.containers.copyGitConfig": false' \
+    assert_grep '"dev.containers.copyGitConfig": false' \
                 /home/testuser/.vscode-server/data/Machine/settings.json
 }
 
@@ -68,7 +68,7 @@ test_server_dir_home_old_symlink() {
     ln -s /bah/bah /home/testuser/.vscode-server
     code .
     check_home_symlink
-    assert_grep '"remote.containers.copyGitConfig": false' \
+    assert_grep '"dev.containers.copyGitConfig": false' \
                 /home/testuser/.vscode-server/data/Machine/settings.json
 }
 

--- a/tests/test-settings-edit.sh
+++ b/tests/test-settings-edit.sh
@@ -9,7 +9,7 @@ test_settings_edit_missing() {
 
     assert_contents /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
 {
-  "remote.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
+  "dev.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
 }
 EOF
 }
@@ -30,7 +30,7 @@ EOF
 
     assert_contents /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
 {
-    "remote.containers.dockerPath": "/home/testuser/.local/bin/podman-host",
+    "dev.containers.dockerPath": "/home/testuser/.local/bin/podman-host",
     "test": "blah"
 }
 EOF
@@ -44,7 +44,7 @@ test_settings_edit_change() {
     mkdir -p /home/testuser/.var/app/com.visualstudio.code/config/Code/User
     cat > /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
 {
-    "remote.containers.dockerPath": "/blah/bin/podman-host"
+    "dev.containers.dockerPath": "/blah/bin/podman-host"
 }
 EOF
 
@@ -52,7 +52,7 @@ EOF
 
     assert_contents /home/testuser/.var/app/com.visualstudio.code/config/Code/User/settings.json <<'EOF'
 {
-    "remote.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
+    "dev.containers.dockerPath": "/home/testuser/.local/bin/podman-host"
 }
 EOF
 }


### PR DESCRIPTION
With **Remote - Containers** VSCode extension renamed to **Dev Containers**, its settings prefix has been changed as well: `remote.containers` was deprecated in favour of `dev.containers`.