### PR TITLE
Use bash for exec wrapper script

### DIFF
--- a/podman-host.sh
+++ b/podman-host.sh
@@ -28,7 +28,7 @@ if [ "$1" == "exec" ] ; then
         done
         exec podman exec "${envargs[@]}" "$@"
     '
-    exec flatpak-spawn --host sh -c "$script" - "$@"
+    exec flatpak-spawn --host bash -c "$script" - "$@"
 else
     exec flatpak-spawn --host podman "$@"
 fi


### PR DESCRIPTION
On Debian-like systems, /bin/sh is dash, which does not support the
bash-specific array syntax used in the wrapper script.

Don't assume that sh is bash: explicitly invoke bash.

Fixes https://github.com/owtaylor/toolbox-vscode/issues/29
